### PR TITLE
FIX VERCEL_URL Does not come with https://

### DIFF
--- a/utils/getURL.ts
+++ b/utils/getURL.ts
@@ -1,8 +1,15 @@
 const IS_SERVER = typeof window === "undefined";
 export default function getURL(path: string): URL {
+    console.log(`process.env.NEXT_PUBLIC_SITE_URL: ${process.env.NEXT_PUBLIC_SITE_URL}`)
+    console.log(`process.env.VERCEL_URL: ${process.env.VERCEL_URL}`)
     const serverUrl = process.env.NEXT_PUBLIC_SITE_URL
         ? process.env.NEXT_PUBLIC_SITE_URL
-        : process.env.VERCEL_URL
+        : `https://${process.env.VERCEL_URL}`
+
+    console.log(`serverUrl: ${serverUrl}`)
+
     const baseURL = IS_SERVER ? serverUrl : window.location.origin;
+
+    console.log(`baseURL: ${baseURL}`)
     return new URL(path, baseURL)
 }


### PR DESCRIPTION
NEXT_PUBLIC_SITE_URL points to https://nqc.io.vn
and should only be used in production. For preview, we should use VERCEL_URL