### PR TITLE
[VN-History] Do not optimize video thumbnails

### DIFF
--- a/app/vietnam-history/components/video-card.tsx
+++ b/app/vietnam-history/components/video-card.tsx
@@ -16,6 +16,7 @@ export default function VideoCard(props: VideoCardProps) {
         <div className="card card-compact max-w-[16rem] md:max-w-xs bg-base-100 shadow-lg">
             <figure className="overflow-hidden rounded-md w-fit h-fit">
                 <Image
+                    unoptimized
                     src={props.thumbnail.url}
                     alt={props.title}
                     width={400}


### PR DESCRIPTION
There are over 1,500 thumbnails which exceed the
Hobby (free) plan on Vercel.com