### PR TITLE
Replace hard-coded Medium stats with API calls

### DIFF
--- a/app/components/blog-api.ts
+++ b/app/components/blog-api.ts
@@ -1,0 +1,91 @@
+const sampleMediumUserInfo = {
+    "id": "18307ee2ebb8",
+    "username": "briannqc",
+    "fullname": "Brian NQC",
+    "bio": "Follow me for contents about Golang, Java, Software Architecture and more",
+    "followers_count": 380,
+    "following_count": 5,
+    "image_url": "https://miro.medium.com/1*9uiL79V_6U9yNQw2K_TYkw.png",
+    "twitter_username": "",
+    "is_writer_program_enrolled": true,
+    "allow_notes": true,
+    "medium_member_at": "2023-08-11 06:48:13",
+    "is_suspended": false,
+    "top_writer_in": [],
+    "has_list": true,
+    "is_book_author": false
+}
+
+const sampleMediumArticles = {
+    "associated_articles": [
+        "1fd94f9fb9a1",
+        "3ffe23f11388",
+        "622fc04278cb",
+        "a72fe533b8f4",
+        "b546596c8e6b",
+        "c6f88070aafa",
+        "205362df9c80",
+        "37583980763f",
+        "742a49bc8d89",
+        "8b42610cad81",
+        "c25297226905",
+        "362ca0c91b80",
+        "2e3c2ef448"
+    ]
+}
+
+type MediumUserInfo = typeof sampleMediumUserInfo
+type MediumArticles = typeof sampleMediumArticles
+type MediumStats = {
+    followersCount: number
+    articlesCount: number
+}
+
+export async function fetchMediumStats(): Promise<MediumStats> {
+    if (process.env.RAPID_API_USE_MOCK !== "false") {
+        return {followersCount: 380, articlesCount: 15}
+    }
+
+    const userId = process.env.BRIAN_MEDIUM_USER_ID!
+    const [followersCount, articlesCount] = await Promise.all([
+        fetchMediumFollowersCount(userId),
+        fetchMediumArticlesCount(userId),
+    ])
+    return {
+        followersCount: followersCount,
+        articlesCount: articlesCount
+    }
+}
+
+async function fetchMediumFollowersCount(userId: string): Promise<number> {
+    const path = `user/${userId}`
+    const response = await fetchMediumApi(path)
+    const result: MediumUserInfo = await response.json()
+    return result.followers_count
+}
+
+async function fetchMediumArticlesCount(userId: string): Promise<number> {
+    const path = `user/${userId}/articles`
+    const response = await fetchMediumApi(path)
+    const result: MediumArticles = await response.json()
+    return result.associated_articles.length
+}
+
+async function fetchMediumApi(path: string) {
+    const hostname = process.env.RAPID_API_HOST!
+    const apiKey = process.env.RAPID_API_KEY!
+    const duration5Days = 5 * 24 * 60 * 60
+
+    const url = `https://${hostname}/${path}`
+    const options = {
+        method: 'GET',
+        headers: {
+            'X-RapidAPI-Key': apiKey,
+            'X-RapidAPI-Host': hostname
+        },
+        next: {
+            revalidate: duration5Days
+        }
+    };
+    return fetch(url, options)
+}

--- a/app/components/blog.tsx
+++ b/app/components/blog.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
+import {fetchMediumStats} from "@/app/components/blog-api";
 
-export default function BlogStats() {
+export default async function BlogStats() {
     return (
         <section className="mt-2 grid text-center md:grid-cols-2 md:text-left">
             <LinkedInSummary/>
@@ -18,18 +19,19 @@ function LinkedInSummary() {
         >
             <div
                 className="group rounded-lg border border-transparent px-4 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30">
-                <h2 className={`mb-3 text-xl font-semibold`}>
+                <h2 className="mb-3 text-xl font-semibold">
                     Linked
                     <i className="fa-brands fa-linkedin fa-lg text-[#0072b1]"></i>
                     <ArrowIcon/>
                 </h2>
-                <p className={`m-0 text-sm opacity-50`}>1400+ Engagements ○ 172K+ Impressions</p>
+                <p className="m-0 text-sm opacity-50">1400+ Engagements ○ 172K+ Impressions</p>
             </div>
         </Link>
     );
 }
 
-function MediumSummary() {
+async function MediumSummary() {
+    const {followersCount, articlesCount} = await fetchMediumStats()
     return (
         <Link
             href="https://medium.com/@briannqc"
@@ -38,12 +40,12 @@ function MediumSummary() {
         >
             <div
                 className="group rounded-lg border border-transparent px-4 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30">
-                <h2 className={`mb-3 text-xl font-semibold`}>
+                <h2 className="mb-3 text-xl font-semibold">
                     <i className="fa-brands fa-medium fa-lg"></i>
                     Medium
                     <ArrowIcon/>
                 </h2>
-                <p className={`m-0 text-sm opacity-50`}>300+ followers, 1500+ claps, 10K views monthly</p>
+                <p className="m-0 text-sm opacity-50">{followersCount} followers ○ {articlesCount} articles</p>
             </div>
         </Link>
     );


### PR DESCRIPTION
The API is very expensive, free plan only offers 150 free calls per month. Therefore, we need to catch the response for a long duration: 5 days.