### PR TITLE
[my-visits] Fix - Ignore LEFT if there are ARRIVED after that same day

### DIFF
--- a/app/office-check-in/page.tsx
+++ b/app/office-check-in/page.tsx
@@ -72,7 +72,7 @@ function deserializeDataTime(str: any): DateTime | undefined {
     if (str === undefined) {
         return undefined
     }
-    return DateTime.fromISO(str)
+    return DateTime.fromISO(str).setZone('Asia/Ho_Chi_Minh')
 }
 
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,8 +2,11 @@ services:
   postgres:
     image: postgres
     environment:
-      POSTGRES_PASSWORD: password
+      POSTGRES_DB: verceldb
       POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    volumes:
+      - ./scripts/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
     ports:
       - '54320:5432'
   pg_proxy:

--- a/scripts/docker-entrypoint-initdb.d/0001-create-portfolio-schema.sql
+++ b/scripts/docker-entrypoint-initdb.d/0001-create-portfolio-schema.sql
@@ -1,0 +1,11 @@
+CREATE SCHEMA portfolio;
+
+CREATE TABLE portfolio.place_visits
+(
+    place   varchar(64),
+    action  varchar(50),
+    address varchar(200),
+    at      timestamptz DEFAULT NOW()
+);
+
+CREATE INDEX idx_place_action ON portfolio.place_visits (place, action);

--- a/scripts/docker-entrypoint-initdb.d/0002-create-table-place-visits.sql
+++ b/scripts/docker-entrypoint-initdb.d/0002-create-table-place-visits.sql
@@ -1,0 +1,9 @@
+CREATE TABLE portfolio.place_visits
+(
+    location  varchar(64),
+    action    varchar(50),
+    address   varchar(200),
+    timestamp timestamptz DEFAULT NOW()
+);
+
+CREATE INDEX idx_place_action ON portfolio.place_visits (place, action);


### PR DESCRIPTION
When I go out for lunch and come back, there will probably be 3 records:
[ARRIVED (t0), LEFT (t1), ARRIVED (t2)]. In this case, we should not say
I already left at t2, instead, we should only say I arrived at t1.

This patch makes the API returns undefined leftAt when there are arrivals
to same place on the same day.